### PR TITLE
Add `cleanup: dirty` config option

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -38,7 +38,9 @@ HINT: This module can be used with [Mongofill](https://github.com/mongofill/mong
   default: MongoDb::DUMP_TYPE_JS).
 * dump - path to database dump
 * populate: true - should the dump be loaded before test suite is started.
-* cleanup: true - should the dump be reloaded after each test
+* cleanup: true or 'dirty' - should the dump be reloaded after each test.
+  If cleanup is set to 'dirty', the dump is only reloaded if any data has been written to the db during a test. This is
+  checked using the [dbHash](https://docs.mongodb.com/manual/reference/command/dbHash/) command.
 
 
 ## Actions

--- a/documentation.md
+++ b/documentation.md
@@ -38,8 +38,8 @@ HINT: This module can be used with [Mongofill](https://github.com/mongofill/mong
   default: MongoDb::DUMP_TYPE_JS).
 * dump - path to database dump
 * populate: true - should the dump be loaded before test suite is started.
-* cleanup: true or 'dirty' - should the dump be reloaded after each test.
-  If cleanup is set to 'dirty', the dump is only reloaded if any data has been written to the db during a test. This is
+* cleanup: true - should the dump be reloaded after each test.
+  Boolean or 'dirty'. If cleanup is set to 'dirty', the dump is only reloaded if any data has been written to the db during a test. This is
   checked using the [dbHash](https://docs.mongodb.com/manual/reference/command/dbHash/) command.
 
 

--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -235,6 +235,17 @@ class MongoDb
         $this->dbh = $this->client->{$this->legacy ? 'selectDB' : 'selectDatabase'}($dbName);
     }
 
+    public function getDbHash()
+    {
+        $result = $this->dbh->command(['dbHash' => 1]);
+
+        if (!is_array($result)) {
+            $result = iterator_to_array($result);
+        }
+
+        return isset($result[0]->md5) ? $result[0]->md5 : null;
+    }
+
     /**
      * Determine if this driver is using the legacy extension or not.
      *

--- a/src/Codeception/Module/MongoDb.php
+++ b/src/Codeception/Module/MongoDb.php
@@ -47,7 +47,9 @@ use Codeception\TestInterface;
  *   default: MongoDb::DUMP_TYPE_JS).
  * * dump - path to database dump
  * * populate: true - should the dump be loaded before test suite is started.
- * * cleanup: true - should the dump be reloaded after each test
+ * * cleanup: true - should the dump be reloaded after each test.
+ *   Boolean or 'dirty'. If cleanup is set to 'dirty', the dump is only reloaded if any data has been written to the db during a test. This is
+ *   checked using the [dbHash](https://docs.mongodb.com/manual/reference/command/dbHash/) command.
  *
  */
 class MongoDb extends CodeceptionModule implements RequiresPackage


### PR DESCRIPTION
If cleanup is set to 'dirty', the dump is only reloaded if any data has been written to the db during a test. This is checked using the [dbHash](https://docs.mongodb.com/manual/reference/command/dbHash/) command.

For example, with my project using `cleanup: dirty` make running API tests 3 times faster.

### With normal cleanup
```
Time: 24.91 seconds, Memory: 24.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 44, Assertions: 184, Skipped: 6.
```

### With cleanup dirty
```
Time: 7.64 seconds, Memory: 24.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 44, Assertions: 184, Skipped: 6.
```