### PR TITLE
FIX: driver compatibility with mongoDB 6.0+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1]
+        php: [8.1, 8.2, 8.3, 8.4]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"minimum-stability": "RC",
 	"require": {
-		"php": "^8.0",
+		"php": "^8.1",
 		"codeception/codeception": "^5.0.8",
 		"mongodb/mongodb": "^1.12"
 	},

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"minimum-stability": "RC",
 	"require": {
 		"php": "^8.0",
-		"codeception/codeception": "^5.0",
+		"codeception/codeception": "^5.0.8",
 		"mongodb/mongodb": "^1.12"
 	},
 	"autoload": {
@@ -25,6 +25,7 @@
 		"classmap-authoritative": true
 	},
 	"require-dev": {
-		"codeception/stub": "^4.0"
+		"codeception/stub": "^4.0",
+		"behat/gherkin": "^4.12"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ composer require "codeception/module-mongodb" --dev
 
 ## Requirements
 
-* `PHP 8.0` or higher.
+* `PHP 8.1` or higher.
 
 ## Documentation
 

--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -112,7 +112,7 @@ class MongoDb
     public function load(string $dumpFile): void
     {
         $cmd = sprintf(
-            'mongo %s %s%s',
+            'mongosh %s %s%s',
             $this->host . '/' . $this->dbName,
             $this->createUserPasswordCmdString(),
             escapeshellarg($dumpFile)

--- a/tests/unit/Codeception/Module/MongoDbTest.php
+++ b/tests/unit/Codeception/Module/MongoDbTest.php
@@ -41,7 +41,7 @@ final class MongoDbTest extends Unit
             $this->markTestSkipped('MongoDB is not installed');
         }
 
-        $cleanupDirty = in_array('cleanup-dirty', $this->getGroups());
+        $cleanupDirty = in_array('cleanup-dirty', $this->groups());
         $config = $this->mongoConfig + ['cleanup' => $cleanupDirty ? 'dirty' : true];
 
         $client = new \MongoDB\Client();


### PR DESCRIPTION
+ compatibility fix with phpunit 10+ due to codeception/codeception 5.0.8+ requirement
+ locking min behat/gherkin package version for dev requirement due to compatibility issues between codeception 5.0.8 and 5.2.1
+ FIX: MongoDb driver is incompatible with any mongoDB versions as of 6.0, since the mongo shell script was completely removed and replaced with mongosh
+ NOTE: testCleanupDirty test function might be broken for a while as it wasn't changed. It expects an early cleanup not to be executed, however nothing indicates that it should change from it's default value, so shouldCleanup returns true, which initiates a cleanup.
+ Dropping support for php 8.0 as it isn't a supported version as of 26 Nov 2023(https://www.php.net/eol.php)
+ Workflows tests support for currently supported php versions(8.1, 8.2, 8.3, 8.4)