### PR TITLE
Fix CI, update PHP support and MongoDB driver

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,19 +13,35 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
-    - name: Setup PHP
+    - name: Setup PHP != 8.5
+      if: ${{ matrix.php != '8.5' }}
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
         extensions: mbstring, xml, dom, mongodb
         tools: pecl
         coverage: none
+      env:
+        fail-fast: true
+
+    - name: Setup PHP 8.5
+      if: ${{ matrix.php == '8.5' }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: mbstring, xml, dom, mongodb
+        tools: pecl
+        coverage: none
+        # this ini directive seems to be off by default in PHP 8.5
+        # see https://github.com/php/php-src/issues/20279
+        # enable it because codeception relies on it.
+        ini-values: register_argc_argv=1
       env:
         fail-fast: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,15 @@ jobs:
       env:
         fail-fast: true
 
+    - name: Install mongodb-database-tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y wget gnupg
+        wget -qO - https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg --dearmor -o /usr/share/keyrings/mongodb-server-8.0.gpg
+        echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+        sudo apt-get update
+        sudo apt-get install -y mongodb-database-tools mongodb-mongosh
+
     - name: Validate composer.json and composer.lock
       run: composer validate
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": "^8.0",
 		"codeception/codeception": "^5.0",
-		"mongodb/mongodb": "^1.12"
+		"mongodb/mongodb": "^1.12 || ^2.0"
 	},
 	"autoload": {
 		"classmap": [

--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -112,7 +112,7 @@ class MongoDb
     public function load(string $dumpFile): void
     {
         $cmd = sprintf(
-            'mongo %s %s%s',
+            'mongosh %s %s%s',
             $this->host . '/' . $this->dbName,
             $this->createUserPasswordCmdString(),
             escapeshellarg($dumpFile)

--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -111,13 +111,36 @@ class MongoDb
      */
     public function load(string $dumpFile): void
     {
+        $shell = $this->findMongoShellBinary();
+        $uri = $this->host . '/' . $this->dbName;
+
         $cmd = sprintf(
-            'mongosh %s %s%s',
-            $this->host . '/' . $this->dbName,
+            '%s %s %s%s',
+            $shell,
+            $uri,
             $this->createUserPasswordCmdString(),
             escapeshellarg($dumpFile)
         );
         shell_exec($cmd);
+    }
+
+    private function findMongoShellBinary(): string
+    {
+        if ($this->commandExists('mongosh')) {
+            return 'mongosh';
+        }
+        if ($this->commandExists('mongo')) {
+            return 'mongo';
+        }
+        
+        throw new ModuleException($this, 'Neither mongosh nor mongo found in PATH.');
+    }
+
+    private function commandExists(string $cmd): bool
+    {
+        $which = sprintf('command -v %s 2>/dev/null', $cmd);
+        $out = shell_exec($which);
+        return is_string($out) && trim($out) !== '';
     }
 
     public function loadFromMongoDump(string $dumpFile): void

--- a/src/Codeception/Lib/Driver/MongoDb.php
+++ b/src/Codeception/Lib/Driver/MongoDb.php
@@ -126,21 +126,28 @@ class MongoDb
 
     private function findMongoShellBinary(): string
     {
-        if ($this->commandExists('mongosh')) {
-            return 'mongosh';
-        }
         if ($this->commandExists('mongo')) {
             return 'mongo';
         }
-        
+
+        if ($this->commandExists('mongosh')) {
+            return 'mongosh';
+        }
+
         throw new ModuleException($this, 'Neither mongosh nor mongo found in PATH.');
     }
 
     private function commandExists(string $cmd): bool
     {
-        $which = sprintf('command -v %s 2>/dev/null', $cmd);
-        $out = shell_exec($which);
-        return is_string($out) && trim($out) !== '';
+        $null = PHP_OS_FAMILY === 'Windows' ? 'NUL' : '/dev/null';
+
+        exec(
+            sprintf('%s --version > %s 2>&1', escapeshellcmd($cmd), $null),
+            $_,
+            $code
+        );
+
+        return $code === 0;
     }
 
     public function loadFromMongoDump(string $dumpFile): void

--- a/tests/unit/Codeception/Module/MongoDbTest.php
+++ b/tests/unit/Codeception/Module/MongoDbTest.php
@@ -41,25 +41,25 @@ final class MongoDbTest extends Unit
             $this->markTestSkipped('MongoDB is not installed');
         }
 
-        $cleanupDirty = in_array('cleanup-dirty', $this->getGroups());
-        $config = $this->mongoConfig + ['cleanup' => $cleanupDirty ? 'dirty' : true];
-
         $client = new \MongoDB\Client();
 
-        $container = Stub::make(ModuleContainer::class);
-        $this->module = new MongoDb($container);
-        $this->module->_setConfig($config);
-        try {
-            $this->module->_initialize();
-        } catch (ModuleException $moduleException) {
-            $this->markTestSkipped($moduleException->getMessage());
-        }
+        $this->initMongoModule(true);
 
         $this->db = $client->selectDatabase('test');
         $this->userCollection = $this->db->users;
 
-        if (!$cleanupDirty) {
-            $this->userCollection->insertOne(['id' => 1, 'email' => 'miles@davis.com']);
+        $this->userCollection->insertOne(['id' => 1, 'email' => 'miles@davis.com']);
+    }
+
+    private function initMongoModule($cleanup): void
+    {
+        $container = Stub::make(ModuleContainer::class);
+        $this->module = new MongoDb($container);
+        $this->module->_setConfig($this->mongoConfig + ['cleanup' => $cleanup]);
+        try {
+            $this->module->_initialize();
+        } catch (ModuleException $moduleException) {
+            $this->markTestSkipped($moduleException->getMessage());
         }
     }
 
@@ -181,11 +181,10 @@ final class MongoDbTest extends Unit
         }
     }
 
-    /**
-     * @group cleanup-dirty
-     */
     public function testCleanupDirty()
     {
+        $this->initMongoModule('dirty');
+
         $test = $this->createMock(\Codeception\TestInterface::class);
         $collection = $this->db->selectCollection('96_bulls');
 


### PR DESCRIPTION
## Summary

This pull request modernizes the MongoDB module and fixes CI issues caused by recent
changes in PHPUnit, PHP versions, and MongoDB tooling. It also adds support for the
latest major version of the MongoDB PHP driver.

---

## Changes

### PHPUnit compatibility
- **[BC BREAK]** Removed usage of `PHPUnit\Framework\TestCase::getGroups()`, which was
  removed in recent PHPUnit versions.
- Updated the module to work correctly with current PHPUnit releases.

### MongoDB database tools
- Added missing dependencies required by the `mongodb-database-tools` environment.
- This fixes CI failures related to MongoDB dump/restore operations.

### PHP version support
- **Added support** for:
  - PHP 8.2
  - PHP 8.3
  - PHP 8.4
  - PHP 8.5

### MongoDB PHP driver
- Added support for **`mongodb/mongodb` v2.x**.
- Ensures compatibility with the latest official MongoDB PHP library.

---

## Motivation

The goal of this change is to:
- Fix CI failures
- Align the MongoDB module with currently supported PHP versions
- Support the latest MongoDB PHP driver

---

## Checklist

- [x] CI fixed and passing
- [x] PHPUnit compatibility updated
- [x] PHP support matrix updated
- [x] MongoDB driver v2 supported